### PR TITLE
Make it work in DF

### DIFF
--- a/API/Data.lua
+++ b/API/Data.lua
@@ -48,18 +48,18 @@ EasyDestroy.Dict.Actions = {}
 
 EasyDestroy.Dict.Actions[1] = {
 	spellID = 13262,
-	itemTypes = {{itype=LE_ITEM_CLASS_WEAPON, stype=nil}, {itype=LE_ITEM_CLASS_ARMOR, stype=nil}},
+	itemTypes = {{itype=Enum.ItemClass.Weapon, stype=nil}, {itype=Enum.ItemClass.Armor, stype=nil}},
 }
 
 EasyDestroy.Dict.Actions[2] = {
 	spellID = 51005,
-	itemTypes = {{itype=LE_ITEM_CLASS_TRADEGOODS, stype=9}},
+	itemTypes = {{itype=Enum.ItemClass.Tradegoods, stype=9}},
 	tradeskill = 773,
 }
 
 EasyDestroy.Dict.Actions[4] = {
 	spellID = 31252,
-	itemTypes = {{itype=LE_ITEM_CLASS_TRADEGOODS, stype=7}},
+	itemTypes = {{itype=Enum.ItemClass.Tradegoods, stype=7}},
 	tradeskill = 755,
 	
 }

--- a/API/Destroy.lua
+++ b/API/Destroy.lua
@@ -5,11 +5,11 @@ EasyDestroy.Destroy.name = "EasyDestroy.Destroy"
 function EasyDestroy.Destroy.GetDestroyActionForItem(item)
 
     if item then 
-        if item.classID == LE_ITEM_CLASS_ARMOR or item.classID == LE_ITEM_CLASS_WEAPON then
+        if item.classID == Enum.ItemClass.Armor or item.classID == Enum.ItemClass.Weapon then
             return EasyDestroy.Enum.Actions.Disenchant
-        elseif item.classID == LE_ITEM_CLASS_TRADEGOODS and item.subclassID == 7 then
+        elseif item.classID == Enum.ItemClass.Tradegoods and item.subclassID == 7 then
             return EasyDestroy.Enum.Actions.Prospect
-        elseif item.classID == LE_ITEM_CLASS_TRADEGOODS and item.subclassID == 9 then
+        elseif item.classID == Enum.ItemClass.Tradegoods and item.subclassID == 9 then
             return EasyDestroy.Enum.Actions.Mill
         end
     end
@@ -21,6 +21,7 @@ end
 function EasyDestroy.Destroy.DestroyItem(item)
 
 	local action = EasyDestroy.Destroy.GetDestroyActionForItem(item)
+	EasyDestroy.Debug("Destroy Action", action)
 
 	if action then
 
@@ -28,9 +29,13 @@ function EasyDestroy.Destroy.DestroyItem(item)
 		local spellname = GetSpellInfo(ActionDict.spellID)
 
 		local bag, slot = EasyDestroy.Inventory.FindTradegoodInBags(item)
+		
+		EasyDestroy.Debug(spellname, bag, slot)
 
 		EasyDestroyButton:SetAttribute("*type1", "macro")
 		EasyDestroyButton:SetAttribute("macrotext", string.format(EasyDestroy.Dict.Strings.DestroyMacro, spellname, bag, slot))
+		
+		EasyDestroy.Debug(EasyDestroyButton:GetAttribute("macrotext"))
 
 	end
 

--- a/API/EasyDestroyItem.lua
+++ b/API/EasyDestroyItem.lua
@@ -6,6 +6,8 @@
 
 EasyDestroyItem = {}
 EasyDestroyItem.__index = EasyDestroyItem
+local GetContainerItemInfo = C_Container.GetContainerItemInfo
+
 function EasyDestroyItem:_NewFromLink(link)
 
     -- private function to handle caching of new items from links
@@ -24,8 +26,8 @@ function EasyDestroyItem:_NewFromBagAndSlot(bag, slot)
 
     -- private function to handle caching of new items from bags/slots
 
-    local ilink = select(7, GetContainerItemInfo(bag, slot))
-    local cache = EasyDestroyItem.EasyDestroyCacheID(bag, slot, ilink)
+    local itemInfo = GetContainerItemInfo(bag, slot)
+    local cache = EasyDestroyItem.EasyDestroyCacheID(bag, slot, itemInfo.hyperlink)
 
     if cache and EasyDestroy.Cache.ItemCache[cache] then
         return EasyDestroy.Cache.ItemCache[cache]
@@ -64,7 +66,7 @@ function EasyDestroyItem:New(bag, slot, link)
     self.isKeystone = C_Item.IsItemKeystoneByID(self.itemID or self.itemLink)
     self.classID, self.subclassID, self.bindtype, self.expansion = select(12, GetItemInfo(self:GetItemLink()))
     self.name = self:GetItemName()
-    self.soulbound = C_Item.IsBound(itemLoc)
+    self.soulbound = self:HasItemLocation() and C_Item.IsBound(itemLoc) or false
     self.count = 1
 
     self.maxStackSize  = select(8, GetItemInfo(self:GetItemLink()))

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+20230206 - 3.2.0
+- Updated TOC file
+- changes to access updated Blizzard container API
+- changes from LE lua enums to Enum.* enums
+
 20220519 - 3.1.2
 - Updated TOC file
 

--- a/EasyDestroy.toc
+++ b/EasyDestroy.toc
@@ -1,5 +1,5 @@
-## Interface: 90200
-## Version: 3.1.2
+## Interface: 100005
+## Version: 3.2.0
 ## Title: EasyDestroy
 ## Notes: Makes disenchanting easy!
 ## Author: CWAGrant

--- a/EasyDestroy.xml
+++ b/EasyDestroy.xml
@@ -82,6 +82,7 @@
 					</Anchors>
 				</Frame>
 			</Frames>
+			<!-- TODO Update for DF
 			<Backdrop bgFile="Interface\Tooltips\UI-Tooltip-Background"
 				edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
 				<BackgroundInsets>
@@ -91,6 +92,7 @@
 				<TileSize val="16"/>
 				<Color a="1" r="0" g="0" b="0" />
 			</Backdrop>
+			-->
 		</Frame>
 
 		<Frame name="EasyDestroyConfiguration" parentKey="FilterConfiguration">

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@ Originally this was a relatively simple addon I made to make it easier to mass d
 
 Can be found at https://github.com/cwagrant/EasyDestroy
 
+### Known Issues:
+	- (v3.2.0)
+		- The EasyDestroy Macro does not currently work. You have to manually click the "Destroy" button. This appears to likely be based on changes to the /click command by Blizzard and I may not be able to re-enable the feature. Time will tell.
+		- Does not show or work for prospecting or milling Dragonflight ores and herbs.
+
  
 ### Commands: 
 

--- a/Templates.lua
+++ b/Templates.lua
@@ -8,7 +8,7 @@ function EasyDestroyItemsMixin:UpdateItemFrame(item, onclick)
         end)
         --self.Item.itemLink = link
 
-        if item.classID == LE_ITEM_CLASS_TRADEGOODS and item.count and item.count > 1 then 
+        if item.classID == Enum.ItemClass.Tradegoods and item.count and item.count > 1 then 
             self.Item:SetText(item:GetItemName() .. " (" .. item.count .. ")")
             self.ItemLevel:SetText("")
         elseif item.level and item.level ~= nil and item.level ~= 0 then

--- a/Templates.xml
+++ b/Templates.xml
@@ -280,10 +280,12 @@
 		In order to get around this I had to use an InsecureActionButtonTemplate. Couldn't find any good documentation
 		of this functionality or limits on the SecureActionButtonTemplate so this is sort of bestguess as to why it didn't work. -->
 	</Frames>
+	<!--- gone in DF, need to find replacement?
 	<Backdrop edgeFile="Interface\Buttons\WHITE8x8" tile="true">			
 		<EdgeSize val="2"/>
 		<BorderColor a="1" r="0.99" g="0.81" b="0"/>
 	</Backdrop>
+	-->
 </Frame>
 <Frame name="EasyDestroyItemScrollTemplate" inherits="BackdropTemplate" virtual="true" mixin="EasyDestroyScrollMixin">
 	<Anchors>

--- a/UI/Blacklist.lua
+++ b/UI/Blacklist.lua
@@ -55,7 +55,7 @@ function protected.GetItemsInBags()
 
                 if not typematch then
                     break
-                elseif item.classID == LE_ITEM_CLASS_ARMOR and item.subclassID == LE_ITEM_ARMOR_COSMETIC then
+                elseif item.classID == Enum.ItemClass.Armor and item.subclassID == Enum.ItemArmorSubclass.Cosmetic then
                     break
                 elseif EasyDestroy.Blacklist.HasItem(item) then
                     break
@@ -119,10 +119,10 @@ function protected.OnFrameShow()
     leftframe:SetPoint("RIGHT", frame, -24, 0)
     leftframe:SetPoint("TOP", frame, 0, -46)
     leftframe:SetPoint("BOTTOM", frame, "CENTER", 0, 16)
-    local bagitems = leftframe:CreateFontString(leftframe, "OVERLAY", "GameFontHighlight")
+    local bagitems = leftframe:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     bagitems:SetPoint("BOTTOMLEFT", leftframe, "TOPLEFT", -4, 20)
     bagitems:SetText("Items in Bag:")
-    local bihelp = leftframe:CreateFontString(leftframe, "OVERLAY", "GameFontHighlight")
+    local bihelp = leftframe:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     bihelp:SetPoint("TOPLEFT", bagitems, "BOTTOMLEFT", 0, 0)
     bihelp:SetText("To add/remove items from the Items Backlist, just click the item in the windows below.")
     -- EasyDestroy:CreateBG(leftframe, 0, 1, 0)
@@ -133,10 +133,10 @@ function protected.OnFrameShow()
     rightframe:SetPoint("RIGHT", frame, -24, 0)
     rightframe:SetPoint("TOP", frame, "CENTER", 0, -32)
     rightframe:SetPoint("BOTTOM", frame, 0, 20)
-    local blitems = rightframe:CreateFontString(rightframe, "OVERLAY", "GameFontHighlight")
+    local blitems = rightframe:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     blitems:SetPoint("BOTTOMLEFT", rightframe, "TOPLEFT", -4, 20)
     blitems:SetText("Items in Blacklist:")
-    local blwarn = rightframe:CreateFontString(rightframe, "OVERLAY", "GameFontHighlight")
+    local blwarn = rightframe:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     blwarn:SetPoint("TOPLEFT", blitems, "BOTTOMLEFT", 0, 0)
     blwarn:SetText("NOTE: This blacklist does not list items filtered by 'blacklist' type filters.")
 

--- a/UI/Dialogs.lua
+++ b/UI/Dialogs.lua
@@ -70,7 +70,7 @@ StaticPopupDialogs["ED_RELOAD_CURRENT_FILTER"] = {
     button2 = "Cancel",
     OnAccept = function(self) 
         EasyDestroy.Data.Options.CharacterFavorites = not EasyDestroy.Data.Options.CharacterFavorites 
-        EasyDestroy.UI.ReloadCurrentFilter()
+        EasyDestroy.UI.Filters.ReloadCurrentFilter()
     end, 
     OnCancel = function(self, data) data:SetChecked(EasyDestroy.Data.Options.CharacterFavorites) end,
     timeout = 30,

--- a/UI/EasyDestroy.lua
+++ b/UI/EasyDestroy.lua
@@ -87,6 +87,7 @@ function EasyDestroyFrame.__init()
     EasyDestroyFrame:SetScript("OnShow", protected.RegisterEvents)
     EasyDestroyFrame:SetScript("OnHide", protected.UnregisterEvents)
 
+	EasyDestroyButton:RegisterForClicks("AnyDown")
     EasyDestroyButton:SetScript("PreClick", protected.DestroyPreClick)
     EasyDestroyButton:SetScript("PostClick", 
 	function(self)

--- a/UI/ItemWindow.lua
+++ b/UI/ItemWindow.lua
@@ -65,7 +65,7 @@ function protected.FindWhitelistItems(activeFilter)
 			--[[ a way to get "continue" statement functionality from break statements. ]]
 			while (true) do
 
-				if item.classID ~= LE_ITEM_CLASS_ARMOR and item.classID ~= LE_ITEM_CLASS_WEAPON and item.count and item.count <= 0 then
+				if item.classID ~= Enum.ItemClass.Armor and item.classID ~= Enum.ItemClass.Weapon and item.count and item.count <= 0 then
 					matchfound = false
 					break
 				end
@@ -78,7 +78,7 @@ function protected.FindWhitelistItems(activeFilter)
 
 				-- can't typically disenchant cosmetic items. This filters them out (hopefully)
 				-- Not sure about cosmetic weapons...
-				if item.classID==LE_ITEM_CLASS_ARMOR and item.subclassID == LE_ITEM_ARMOR_COSMETIC then
+				if item.classID==Enum.ItemClass.Armor and item.subclassID == Enum.ItemArmorSubclass.Cosmetic then
 					matchfound = false
 					break
 				end

--- a/UI/Options.lua
+++ b/UI/Options.lua
@@ -221,7 +221,7 @@ function EasyDestroy_OnOptionsShow()
     addonOptions:SetBackdropBorderColor(0,0,0,1)
     addonOptions:Show()
 
-    addonOptions.label = addonOptions:CreateFontString(addonOptions, "OVERLAY", "GameTooltipText")
+    addonOptions.label = addonOptions:CreateFontString(nil, "OVERLAY", "GameTooltipText")
     addonOptions.label:SetPoint("BOTTOMLEFT", addonOptions, "TOPLEFT", 4 , 2)
     addonOptions.label:SetText("EasyDestroy Options")
     optionsFrame.addonOptions = addonOptions
@@ -244,7 +244,7 @@ function EasyDestroy_OnOptionsShow()
     destroyOptions:SetBackdropBorderColor(0,0,0,1)
     destroyOptions:Show()
 
-    destroyOptions.label = destroyOptions:CreateFontString(destroyOptions, "OVERLAY", "GameTooltipText")
+    destroyOptions.label = destroyOptions:CreateFontString(nil, "OVERLAY", "GameTooltipText")
     destroyOptions.label:SetPoint("BOTTOMLEFT", destroyOptions, "TOPLEFT", 4, 2)
     destroyOptions.label:SetText("Search & Destroy Options")
     optionsFrame.destroyOptions = destroyOptions

--- a/filters/bind.lua
+++ b/filters/bind.lua
@@ -11,7 +11,7 @@ function filter:Initialize()
     -- We create the frame here, we'll leave the details on size/anchors to the Filters window.
     self.frame = self.frame or CreateFrame("Frame", nil, self.parent)
 
-    self.label = self.frame:CreateFontString(self.frame, "OVERLAY", "GameFontNormalSmall")
+    self.label = self.frame:CreateFontString(nil, "ARTWORK", "GameFontNormalSmall")
     self.label:SetPoint("CENTER", self.frame, "TOP", 0, -10)
     self.label:SetText(self.name)
     

--- a/filters/count.lua
+++ b/filters/count.lua
@@ -40,7 +40,7 @@ end
 
 function filter:Clear()
     if self.frame then
-        self.frame.input:SetNumber("")
+        self.frame.input:SetNumber(0)
     end
 end
 

--- a/filters/itemtype.lua
+++ b/filters/itemtype.lua
@@ -9,7 +9,7 @@ function filter:Initialize()
     -- We create the frame here, we'll leave the details on size/anchors to the Filters window.
     self.frame = self.frame or CreateFrame("Frame", nil, self.parent)
 
-    self.label = self.frame:CreateFontString(self.frame, "OVERLAY", "GameFontNormalSmall")
+    self.label = self.frame:CreateFontString(nil, "ARTWORK", "GameFontNormalSmall")
     self.label:SetPoint("CENTER", self.frame, "TOP", 0, -10)
     self.label:SetText(self.name)
 
@@ -36,9 +36,9 @@ end
 function filter:Check(input, item)
 
     if self.frame then
-        if item.classID == LE_ITEM_CLASS_ARMOR or item.classID == LE_ITEM_CLASS_WEAPON then 
+        if item.classID == Enum.ItemClass.Armor or item.classID == Enum.ItemClass.Weapon then 
             return (bit.band(input, GEAR) > 0)
-        elseif item.classID == LE_ITEM_CLASS_TRADEGOODS then
+        elseif item.classID == Enum.ItemClass.Tradegoods then
             if item.subclassID == 7 then
                 return (bit.band(input, ORE) > 0)
             elseif item.subclassID == 9 then


### PR DESCRIPTION
In order for EasyDestory to work in Dragonflight a number of api changes needed to be made to interface with the container item methods that were namespaced (and updated).

Additionally a number of ENUMS were updated at some point which may have been the source of people not seeing items. Seems strange that the issue didn't impact me until DF though others apparently were suffering from the issue earlier. Maybe something on Blizzards end?